### PR TITLE
✨ elder_id를 Vapi metadata로 전달하는 기능 구현

### DIFF
--- a/CallClient/Dependencies/APIClient/APIClient+Live.swift
+++ b/CallClient/Dependencies/APIClient/APIClient+Live.swift
@@ -14,9 +14,13 @@ extension APIClient: DependencyKey {
     static let liveValue = Self(
         verifyInviteCode: { inviteCode, deviceToken in
             do {
-                // TODO: 실제 서버 URL로 변경 필요
-                let baseURL = "http://localhost:8000"
+                // Mac 로컬 서버 주소 (실기기 테스트용)
+                // localhost는 실기기에서 작동하지 않으므로 Mac의 IP 사용
+                let baseURL = "http://10.19.211.245:8000"
                 let url = URL(string: "\(baseURL)/elder-app/invitation-code")!
+                
+                print("🌐 API 요청: \(url.absoluteString)")
+                print("📤 invite_code: \(inviteCode), device_token: \(deviceToken)")
                 
                 var request = URLRequest(url: url)
                 request.httpMethod = "POST"
@@ -32,11 +36,22 @@ extension APIClient: DependencyKey {
                 let (data, response) = try await URLSession.shared.data(for: request)
                 
                 guard let httpResponse = response as? HTTPURLResponse else {
+                    print("❌ API 응답 에러: Invalid HTTP Response")
                     throw APIError.invalidResponse
                 }
                 
+                print("📥 API 응답: HTTP \(httpResponse.statusCode)")
+                
                 guard (200...299).contains(httpResponse.statusCode) else {
+                    print("❌ API 에러: HTTP \(httpResponse.statusCode)")
+                    if let errorBody = String(data: data, encoding: .utf8) {
+                        print("   에러 내용: \(errorBody)")
+                    }
                     throw APIError.httpError(statusCode: httpResponse.statusCode)
+                }
+                
+                if let responseBody = String(data: data, encoding: .utf8) {
+                    print("✅ API 성공 응답: \(responseBody)")
                 }
                 
                 let result = try JSONDecoder().decode(VerifyCodeResponse.self, from: data)

--- a/CallClient/Dependencies/APIClient/APIClient.swift
+++ b/CallClient/Dependencies/APIClient/APIClient.swift
@@ -13,7 +13,8 @@ import Foundation
 @DependencyClient
 struct APIClient {
     var verifyInviteCode: @Sendable (String, String) async -> Result<VerifyCodeResponse, Error> = { _, _ in
-            .success(VerifyCodeResponse(success: true, message: "success"))
+            .success(VerifyCodeResponse(success: true,
+                                        message: "success", elder_id: 1, elder_name: "Test Elder"))
     }
 }
 

--- a/CallClient/Dependencies/AuthStateClient/AuthStateClient.swift
+++ b/CallClient/Dependencies/AuthStateClient/AuthStateClient.swift
@@ -15,6 +15,8 @@ struct AuthStateClient {
     var saveAuthState: @Sendable (String) async -> Void
     var getAuthState: @Sendable () async -> String?
     var clearAuthState: @Sendable () async -> Void
+    var saveElderId: @Sendable (Int) async -> Void
+    var getElderId: @Sendable () async -> Int?
 }
 
 // MARK: - Dependency Values
@@ -22,6 +24,7 @@ struct AuthStateClient {
 extension AuthStateClient: DependencyKey {
     static let liveValue: AuthStateClient = {
         let authKey = "invite_code_verified"
+        let elderIdKey = "elder_id"
         
         return AuthStateClient(
             saveAuthState: { inviteCode in
@@ -33,7 +36,16 @@ extension AuthStateClient: DependencyKey {
             },
             clearAuthState: {
                 UserDefaults.standard.removeObject(forKey: authKey)
+                UserDefaults.standard.removeObject(forKey: elderIdKey)
                 print("🗑️ 초대 코드 인증 상태 삭제됨")
+            },
+            saveElderId: { elderId in
+                UserDefaults.standard.set(elderId, forKey: elderIdKey)
+                print("💾 Elder ID 저장됨:", elderId)
+            },
+            getElderId: {
+                let elderId = UserDefaults.standard.integer(forKey: elderIdKey)
+                return elderId == 0 ? nil : elderId
             }
         )
     }()
@@ -43,7 +55,9 @@ extension AuthStateClient: TestDependencyKey {
     static let testValue = AuthStateClient(
         saveAuthState: { _ in },
         getAuthState: { nil },
-        clearAuthState: { }
+        clearAuthState: { },
+        saveElderId: { _ in },
+        getElderId: { nil }
     )
 }
 

--- a/CallClient/Dependencies/VapiClient/VapiClient+Live.swift
+++ b/CallClient/Dependencies/VapiClient/VapiClient+Live.swift
@@ -84,16 +84,45 @@ extension VapiClient: DependencyKey {
         let eventStreamManager = EventStreamManager()
 
         return Self(
-            start: {
+            start: { elderId in
+                print("🔄 VapiClient: start() 호출됨 - elderId: \(elderId?.description ?? "nil")")
+                
                 // Audio Session 설정
                 let audioSession = AVAudioSession.sharedInstance()
-                try audioSession.setCategory(.playAndRecord, options: [.allowBluetooth, .defaultToSpeaker])
-                try audioSession.setMode(.voiceChat)
-                try audioSession.setActive(true)
-                print("✅ VapiClient: Audio session configured")
+                do {
+                    try audioSession.setCategory(.playAndRecord, options: [.allowBluetooth, .defaultToSpeaker])
+                    try audioSession.setMode(.voiceChat)
+                    try audioSession.setActive(true)
+                    print("✅ VapiClient: Audio session configured")
+                } catch {
+                    print("❌ VapiClient: Audio session 설정 실패 - \(error.localizedDescription)")
+                    throw error
+                }
+
+                // Metadata 생성
+                var assistantOverrides: [String: Any] = [:]
+                if let elderId = elderId {
+                    assistantOverrides["metadata"] = ["elder_id": elderId]
+                    print("📦 VapiClient: Metadata 생성 완료 - elder_id: \(elderId)")
+                } else {
+                    print("⚠️ VapiClient: elder_id가 없어 metadata 없이 통화 시작")
+                }
 
                 // Vapi 통화 시작
-                try await vapi.start(assistantId: assistantId)
+                print("🚀 VapiClient: Vapi SDK start() 호출 시작...")
+                print("   - assistantId: \(assistantId)")
+                print("   - assistantOverrides: \(assistantOverrides)")
+                
+                do {
+                    try await vapi.start(
+                        assistantId: assistantId,
+                        assistantOverrides: assistantOverrides
+                    )
+                    print("✅ VapiClient: Vapi SDK start() 호출 성공!")
+                } catch {
+                    print("❌ VapiClient: Vapi SDK start() 호출 실패 - \(error.localizedDescription)")
+                    throw error
+                }
             },
             stop: {
                 vapi.stop()

--- a/CallClient/Dependencies/VapiClient/VapiClient.swift
+++ b/CallClient/Dependencies/VapiClient/VapiClient.swift
@@ -12,7 +12,7 @@ import Foundation
 
 @DependencyClient
 struct VapiClient {
-    var start: @Sendable () async throws -> Void
+    var start: @Sendable (Int?) async throws -> Void
     var stop: @Sendable () -> Void
     var setMuted: @Sendable (Bool) async throws -> Void
     var eventStream: @Sendable () -> AsyncStream<VapiEvent> = { AsyncStream { _ in } }

--- a/CallClient/Features/Call/CallFeature.swift
+++ b/CallClient/Features/Call/CallFeature.swift
@@ -58,6 +58,7 @@ struct CallFeature {
 
     @Dependency(\.vapiClient) var vapiClient
     @Dependency(\.callKitClient) var callKitClient
+    @Dependency(\.authStateClient) var authStateClient
     @Dependency(\.continuousClock) var clock
     
     private enum CancelID { 
@@ -75,9 +76,12 @@ struct CallFeature {
             case .onAppear:
                 // 통화 시작
                 return .run { send in
+                    // elder_id 가져오기
+                    let elderId = await authStateClient.getElderId()
+                    
                     // Vapi 통화 시작
                     do {
-                        try await vapiClient.start()
+                        try await vapiClient.start(elderId)
                     } catch {
                         await send(.vapiError(error))
                         return

--- a/CallClient/Features/Invitation/InvitationFeature.swift
+++ b/CallClient/Features/Invitation/InvitationFeature.swift
@@ -122,7 +122,7 @@ struct InvitationFeature {
                 print("📧 코드 재발송 요청")
                 return .none
                 
-            case .verifyCodeResponse(.success):
+            case .verifyCodeResponse(.success(let response)):
                 state.isLoading = false
                 state.errorMessage = nil
                 
@@ -133,6 +133,11 @@ struct InvitationFeature {
                 
                 return .run { _ in
                     await authStateClient.saveAuthState(inviteCode)
+                    // elder_id 저장
+                    if let elderId = response.elder_id {
+                        await authStateClient.saveElderId(elderId)
+                        print("✅ Elder ID \(elderId) 저장 완료")
+                    }
                 }
                 
             case .successAlertConfirmTapped:
@@ -169,5 +174,7 @@ struct InvitationFeature {
 struct VerifyCodeResponse: Codable, Equatable {
     let success: Bool
     let message: String?
+    let elder_id: Int?
+    let elder_name: String?
 }
 


### PR DESCRIPTION
- AuthStateClient에 elder_id 저장/조회 메서드 추가
- API 응답 모델에 elder_id, elder_name 필드 추가
- InvitationFeature에서 초대코드 검증 성공 시 elder_id 저장
- VapiClient.start()에 elderId 파라미터 추가 및 metadata 전달
- CallFeature에서 저장된 elder_id 조회하여 통화 시작 시 전달
- API 요청/응답 상세 로그 추가
- Mac 로컬 서버 연결을 위한 IP 주소 설정 (localhost → 10.19.211.245)

관련 이슈: #7